### PR TITLE
fix: migrate to github gateway

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
-  name: git-gateway
-  branch: master
+  name: github
+  repo: williscool/boujeehacker.com
 
 media_folder: static/img
 public_folder: /img


### PR DESCRIPTION
git-gateway is deprecated and not working for my setup

https://docs.netlify.com/security/secure-access-to-sites/git-gateway/
https://decapcms.org/docs/github-backend/
